### PR TITLE
Fixed deprecated order parameter on WC_Gateway_Cecabank::process_payment()

### DIFF
--- a/wc_gateway_cecabank.php
+++ b/wc_gateway_cecabank.php
@@ -306,7 +306,7 @@ function wc_cecabank_gateway_init() {
         public function process_payment( $order_id ) {
             $order = wc_get_order( $order_id );
 
-			$redirect_url = add_query_arg('order', $order->id, add_query_arg('key', $order->order_key, get_permalink(wc_get_page_id('pay'))));
+			$redirect_url = add_query_arg('order-pay', $order->id, add_query_arg('key', $order->order_key, get_permalink(wc_get_page_id('pay'))));
 
             return array(
                     'result'        => 'success',


### PR DESCRIPTION
The _order_ parameter is deprecated and WooCommerce suggest the use of _order-pay_:

> WC_Shortcode_Checkout->output was called with an argument that is <strong>deprecated</strong> since version 2.1! "order" is no longer used to pass an order ID. Use the order-pay or order-received endpoint instead.

This message is shown if you have enabled deprecation warnings in error_reporting().