### PR TITLE
Fix error when POST data is empty

### DIFF
--- a/wc_gateway_cecabank.php
+++ b/wc_gateway_cecabank.php
@@ -662,9 +662,10 @@ function wc_cecabank_gateway_init() {
                 $cecabank_client->checkTransaction($_POST);
             } catch (\Exception $e) {
                 $message = __('Ha ocurrido un error con el pago: '.$e->getMessage(), 'wc-gateway-cecabank');
-                $order = wc_get_order( $_POST['Num_operacion'] );
-                $order->update_status('failed', $message );
-                die();
+                if(isset($_POST['Num_operacion']) && $order = wc_get_order( $_POST['Num_operacion'] )) {
+                    $order->update_status('failed', $message );
+                }
+                die($message);
             }
 
             $order = wc_get_order( $_POST['Num_operacion'] );

--- a/wc_gateway_cecabank.php
+++ b/wc_gateway_cecabank.php
@@ -664,6 +664,7 @@ function wc_cecabank_gateway_init() {
                 $message = __('Ha ocurrido un error con el pago: '.$e->getMessage(), 'wc-gateway-cecabank');
                 if(isset($_POST['Num_operacion']) && $order = wc_get_order( $_POST['Num_operacion'] )) {
                     $order->update_status('failed', $message );
+		    die();
                 }
                 die($message);
             }


### PR DESCRIPTION
Related to https://github.com/cecabank/cecabank-woocommerce/issues/1

Fix error when POST data is empty and print a message, to test it, access directly to www.yourdomain.com/?wc-api=WC_Gateway_Cecabank