### PR TITLE
fix:bug in amount when cents are multiple of 10

### DIFF
--- a/lib/Cecabank/Client.php
+++ b/lib/Cecabank/Client.php
@@ -328,11 +328,17 @@ class Client
             return '000';
         }
 
-        if (preg_match('/[\.,]/', $amount)) {
-            return str_replace(array('.', ','), '', $amount);
+        if(is_string($amount)) {
+            // delete current thousand separator (if exists) from string based on WooCommerce(v2.3+) settings.
+            $amount = str_replace( wc_get_price_thousand_separator(), '', $amount );
+            // replace current decimal separator (if exists) from string based on WooCommerce(v2.3+) settings with a dot.
+            $amount = str_replace( wc_get_price_decimal_separator(), '.', $amount );
         }
+        // convert to cents.
+        $amount = (float) $amount;
+        $amount = ceil( $amount * 100 );
 
-        return (string)($amount * 100);
+        return (string) $amount;
     }
 
     public function getSignature()


### PR DESCRIPTION
This PR fixes a bug in the `Cecabank/Client:getAmount` function that returns an incorrect value when the value of the cents of `$amount` is a number multiple of 10 (for example 29.70 or 10.50).

This error was detected after several customer reports indicating that requested partial returns had been completed with an incorrect value, obtaining only one-tenth of the value sent from WooCommerce.