### PR TITLE
Fix HMAC notification validation and retry acknowledgement

### DIFF
--- a/wc_gateway_cecabank.php
+++ b/wc_gateway_cecabank.php
@@ -767,22 +767,35 @@ function wc_cecabank_gateway_init() {
             global $woocommerce;
 
             $config = $this->get_client_config();
-            $config['Cifrado'] = 'SHA2';
 
             $cecabank_client = new Cecabank\Client($config);
 
             try {
                 $cecabank_client->checkTransaction($_POST);
             } catch (\Exception $e) {
+                wc_get_logger()->error(
+                    'Cecabank notification validation failed: ' . $e->getMessage(),
+                    array( 'source' => 'cecabank' )
+                );
+                status_header( 400 );
                 die();
             }
 
             $order = wc_get_order( $_POST['Num_operacion'] );
 
-            $subscriptions = class_exists( 'WC_Subscriptions_Order' ) && WC_Subscriptions_Order::order_contains_subscription( $order_id );
+            if ( !$order ) {
+                wc_get_logger()->error(
+                    'Cecabank notification references an unknown order.',
+                    array( 'source' => 'cecabank' )
+                );
+                status_header( 404 );
+                die();
+            }
+
+            $subscriptions = class_exists( 'WC_Subscriptions_Order' ) && WC_Subscriptions_Order::order_contains_subscription( $order->get_id() );
 
             if ( !$subscriptions && $order->has_status( 'completed' ) ) {
-                die();
+                die($cecabank_client->successCode());
             }
 
             // Payment completed


### PR DESCRIPTION
## What changed

- preserve the SHA2/HMAC mode selected by `get_client_config()` instead of forcing every incoming notification through SHA2
- log validation failures in the WooCommerce log without logging the signed POST body
- reject notifications for unknown orders explicitly
- use the actual order ID for the subscription check
- return Cecabank's success code for an already-completed order, making duplicate delivery acknowledgement idempotent

## Why

`get_client_config()` selects SHA2 only for legacy 8-character secrets and HMAC otherwise, but `check_notification()` overwrites that choice with SHA2. An HMAC-signed callback will therefore fail `hash_equals()`, get swallowed by the empty catch, and leave an authorized order pending.

The empty response for an already-completed order is also unsafe under at-least-once delivery: Cecabank can interpret a valid duplicate as a failed acknowledgement and retry it again.

Fixes #12.

## Verification

I traced both the callback-validation and duplicate-delivery branches through the current 0.4.1 source. This repository does not include an automated test harness for the gateway callback, so the reporter's Cecabank test transaction remains the appropriate end-to-end verification.